### PR TITLE
ganglia/ganglia_api.py: add fix to handle string types in is_num

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ The following is some example output:
 Debugging
 ---------
 
+The following commands assume the real web server (in this case apache) is
+properly configured to proxy for ganglia_api (on localhost).  Only port 443
+for the webserver is publicly accessible, and digest auth is required. The
+web server is also the same host running the top-level gmetad process for
+at least one ganglia cluster.
+
 For checking proper integration, you need to have a working gmetad where
 you installed ganglia_api.  The tools you will need are:
  - a telnet client for getting xml output from gmetad
@@ -135,6 +141,8 @@ from a remote machine using the public hostname:
 ```
 curl -o ganglia-dump.json -n --digest --header "Accept:application/json" https://myserver.mydomain.com/ganglia/api/v2/metrics?&environment=all&cluster=MyCluster&host=myhost.mydomain.com&grid=MyGrid&metric=load_one
 ```
+
+Substitute your hostnames, etc.
 
 Assuming your filename is the same as shown above, make the output human-readable:
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,48 @@ The following is some example output:
         "total": 1
     }
 
+Debugging
+---------
+
+For checking proper integration, you need to have a working gmetad where
+you installed ganglia_api.  The tools you will need are:
+ - a telnet client for getting xml output from gmetad
+ - curl for getting json output from ganglia_api
+ - python-simplejson for making the json output readable
+ - a .netrc file for curl to auth against the web server
+
+First get some xml metric data from gmetad to verify json values:
+
+```
+ $ telnet localhost 8651 > gmetad_dump.xml
+```
+
+Substitute your port numbers if needed (don't use the interactive port).
+
+Next check ganglia_api directly on localhost:
+
+```
+ $ curl -n --digest --header "Accept:application/json" http://127.0.0.1/ganglia/api/v2/metrics?&environment=all&cluster=MyCluster&host=myhost.mydomain.com&grid=MyGrid&metric=load_one
+```
+
+Substitute your values for grid, cluster, etc.  Add ``-o ganglia-dump.json``
+to capture output to a file.  If localhost is working, try the same thing
+from a remote machine using the public hostname:
+
+```
+curl -o ganglia-dump.json -n --digest --header "Accept:application/json" https://myserver.mydomain.com/ganglia/api/v2/metrics?&environment=all&cluster=MyCluster&host=myhost.mydomain.com&grid=MyGrid&metric=load_one
+```
+
+Assuming your filename is the same as shown above, make the output human-readable:
+
+```
+python -m json.tool ganglia-dump.json > ganglia-dump-pretty.json
+```
+
+Now you can view both files in an editor or use grep to find the values of
+interest.
+
+
 License
 -------
 

--- a/ganglia/ganglia_api.py
+++ b/ganglia/ganglia_api.py
@@ -74,7 +74,7 @@ class ApiMetric:
                   'description': self.desc,
                   'sum': self.sum,
                   'num': self.num,
-                  'value': ApiMetric.is_num(self.val),
+                  'value': ApiMetric.is_num(self.val, self.type),
                   'units': units,
                   'type': type,
                   'sampleTime': datetime.datetime.fromtimestamp(
@@ -98,7 +98,11 @@ class ApiMetric:
         return 'undefined', units
 
     @staticmethod
-    def is_num(val):
+    def is_num(val, type):
+        try:
+            return str(val)
+        except ValueError:
+            pass
         try:
             return int(val)
         except ValueError:

--- a/ganglia/ganglia_api.py
+++ b/ganglia/ganglia_api.py
@@ -74,7 +74,7 @@ class ApiMetric:
                   'description': self.desc,
                   'sum': self.sum,
                   'num': self.num,
-                  'value': ApiMetric.is_num(self.val, self.type),
+                  'value': ApiMetric.is_num(self.val),
                   'units': units,
                   'type': type,
                   'sampleTime': datetime.datetime.fromtimestamp(
@@ -98,7 +98,7 @@ class ApiMetric:
         return 'undefined', units
 
     @staticmethod
-    def is_num(val, type):
+    def is_num(val):
         try:
             return str(val)
         except ValueError:


### PR DESCRIPTION
* this fixes returing Infinity for string value of NNNNNeNNNNN
* note: is_num should probably not use try/except to find the type
  of the metric value (seems more like abuse than pythonic)

Signed-off-by: Steve Arnold <nerdboy@gentoo.org>