### PR TITLE
Pytest cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ language: python
 python:
   - "2.7"
 
+env:
+  - TORNADO_VERSION=5.0
+
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - "pip install -r requirements.txt"
+  - "pip install tornado>=$TORNADO_VERSION"
+  - "pip install pytest"
+  - "pip install pytest-pep8"
+  - "pip install pytest-flake8"
+  - python setup.py install
 
 # command to run tests (no tests yet)
-script: python setup.py install
+script:
+  - pytest --pep8 --flake8

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ganglia API v2
 [![GitHub](https://img.shields.io/github/license/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api)
 [![GitHub version](https://badge.fury.io/gh/teamorchard%2Fganglia_api.svg)](https://badge.fury.io/gh/teamorchard%2Fganglia_api)
 [![Build Status](https://travis-ci.org/teamorchard/ganglia_api.svg?branch=master)](https://travis-ci.org/teamorchard/ganglia_api)
-[![Ebert](https://ebertapp.io/github/teamorchard/ganglia_api.svg)](https://ebertapp.io/github/teamorchard/ganglia_api)
+[![Code Climate](https://codeclimate.com/github/teamorchard/ganglia_api/badges/gpa.svg)](https://codeclimate.com/github/teamorchard/ganglia_api)
 [![Issues](https://img.shields.io/github/issues/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api/issues?q=is:issue+is:open)
 [![Pull Requests](https://img.shields.io/github/issues-pr/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api/issues?q=is:open+is:pr)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Ganglia API v2
 ==============
 
+[![GitHub](https://img.shields.io/github/license/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api)
+[![GitHub version](https://badge.fury.io/gh/teamorchard%2Fganglia_api.svg)](https://badge.fury.io/gh/teamorchard%2Fganglia_api)
+[![Build Status](https://travis-ci.org/teamorchard/ganglia_api.svg?branch=master)](https://travis-ci.org/teamorchard/ganglia_api)
+[![Ebert](https://ebertapp.io/github/teamorchard/ganglia_api.svg)](https://ebertapp.io/github/teamorchard/ganglia_api)
+[![Issues](https://img.shields.io/github/issues/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api/issues?q=is:issue+is:open)
+[![Pull Requests](https://img.shields.io/github/issues-pr/teamorchard/ganglia_api.svg)](https://github.com/teamorchard/ganglia_api/issues?q=is:open+is:pr)
+
 The Ganglia API is a small standalone python application that takes XML data from
 a number of Ganglia gmetad processes and presents a RESTful JSON API of the most
 recently received data.

--- a/ganglia/ganglia_api.py
+++ b/ganglia/ganglia_api.py
@@ -114,7 +114,7 @@ class ApiMetric:
 
     def __str__(self):
         return "%s %s %s %s %s %s" % (
-        self.environment, self.grid.name, self.cluster.name, self.host.name, self.group, self.name)
+                self.environment, self.grid.name, self.cluster.name, self.host.name, self.group, self.name)
 
 
 class Metric(Elem, ApiMetric):
@@ -151,7 +151,8 @@ class Metric(Elem, ApiMetric):
                   "metric": original_metric_name}
         url = '%s%s/metrics?' % (settings.API_SERVER, settings.BASE_URL)
         for (k, v) in params.items():
-            if v is not None: url += "&%s=%s" % (k, quote(v))
+            if v is not None:
+                url += "&%s=%s" % (k, quote(v))
         self.data_url = url
 
         params = {"c": self.cluster.name,
@@ -164,12 +165,13 @@ class Metric(Elem, ApiMetric):
                   "ti": self.title}
         url = '%sgraph.php?' % self.grid.authority
         for (k, v) in params.items():
-            if v is not None: url += "&%s=%s" % (k, quote(v))
+            if v is not None:
+                url += "&%s=%s" % (k, quote(v))
         self.graph_url = url
 
     def __getattr__(self, name):
         try:
-            if self.metadata.has_key(name.upper()):
+            if name.upper() in self.metadata:
                 return self.metadata[name.upper()]
             else:
                 return Elem.__getattr__(self, name)
@@ -178,6 +180,7 @@ class Metric(Elem, ApiMetric):
 
     def html_dir(self):
         return 'ganglia-' + self.environment + '-' + self.grid.name
+
 
 # Artificial metric generated from the Host
 class HeartbeatMetric(ApiMetric):
@@ -222,7 +225,8 @@ class GangliaGmetad:
             return
 
         try:
-            if send is not None: sock.send(send)
+            if send is not None:
+                sock.send(send)
         except socket.error, e:
             logger.warning('Could not send to %s:%d - %s', host, port, e)
             return
@@ -235,7 +239,8 @@ class GangliaGmetad:
                 logger.warning('Could not receive data from %s:%d - %s', host, port, e)
                 return
 
-            if not data: break
+            if not data:
+                break
             buffer += data.decode("ISO-8859-1")
 
         sock.close()
@@ -398,11 +403,11 @@ class ApiHandler(tornado.web.RequestHandler):
             return len(list) == 0 or value in list
 
         def is_match(metric):
-            return (emptyOrContains(metric_list, metric.name)
-                and emptyOrContains(group_list, metric.group)
-                and emptyOrContains(host_list, metric.host.name)
-                and emptyOrContains(cluster_list, metric.cluster.name)
-                and emptyOrContains(grid, metric.grid.name))
+            return (emptyOrContains(metric_list, metric.name) and
+                    emptyOrContains(group_list, metric.group) and
+                    emptyOrContains(host_list, metric.host.name) and
+                    emptyOrContains(cluster_list, metric.cluster.name) and
+                    emptyOrContains(grid, metric.grid.name))
 
         gmetad_list = ganglia_config.get_gmetad_for(environment)
         metric_dicts = list()

--- a/ganglia/settings.py
+++ b/ganglia/settings.py
@@ -2,7 +2,7 @@ DEBUG = True
 
 GANGLIA_PATH = '/etc/ganglia'  # where gmetad.conf is located
 
-API_SERVER = 'http://ganglia-api.example.com:8080'  # where ganglia-api.py is hosted
+API_SERVER = 'http://ganglia-api.example.com:8080'
 BASE_URL = '/ganglia/api/v2'
 
 LOGFILE = '/var/log/ganglia-api.log'

--- a/ganglia/version.py
+++ b/ganglia/version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#-*- coding:utf-8 -*-
+# coding: utf-8
 
 version = "2.0.0a"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+flake8-max-line-length = 124
+
+pep8maxlinelength = 124

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 
 
 import re
-import sys
 from distutils import core, log
 
 import os
@@ -27,51 +26,53 @@ if "GENTOO_PORTAGE_EPREFIX" in EPREFIX:
 
 # Python files that need `version = ""` subbed, relative to this dir:
 python_scripts = [os.path.join(cwd, path) for path in (
-	'ganglia/version.py',
+    'ganglia/version.py',
 )]
 
+
 class set_version(core.Command):
-	"""Set python version to our __version__."""
-	description = "hardcode scripts' version using VERSION from environment"
-	user_options = []  # [(long_name, short_name, desc),]
+    """Set python version to our __version__."""
+    description = "hardcode scripts' version using VERSION from environment"
+    user_options = []  # [(long_name, short_name, desc),]
 
-	def initialize_options (self):
-		pass
+    def initialize_options(self):
+        pass
 
-	def finalize_options (self):
-		pass
+    def finalize_options(self):
+        pass
 
-	def run(self):
-		ver = 'git' if __version__ == '9999' else __version__
-		print("Setting version to %s" % ver)
-		def sub(files, pattern):
-			for f in files:
-				updated_file = []
-				with io.open(f, 'r', 1, 'utf_8') as s:
-					for line in s:
-						newline = re.sub(pattern, '"%s"' % ver, line, 1)
-						if newline != line:
-							log.info("%s: %s" % (f, newline))
-						updated_file.append(newline)
-				with io.open(f, 'w', 1, 'utf_8') as s:
-					s.writelines(updated_file)
-		quote = r'[\'"]{1}'
-		python_re = r'(?<=^version = )' + quote + '[^\'"]*' + quote
-		sub(python_scripts, python_re)
+    def run(self):
+        ver = 'git' if __version__ == '9999' else __version__
+        print("Setting version to %s" % ver)
+
+        def sub(files, pattern):
+            for f in files:
+                updated_file = []
+                with io.open(f, 'r', 1, 'utf_8') as s:
+                    for line in s:
+                        newline = re.sub(pattern, '"%s"' % ver, line, 1)
+                        if newline != line:
+                            log.info("%s: %s" % (f, newline))
+                        updated_file.append(newline)
+                with io.open(f, 'w', 1, 'utf_8') as s:
+                    s.writelines(updated_file)
+
+        quote = r'[\'"]{1}'
+        python_re = r'(?<=^version = )' + quote + '[^\'"]*' + quote
+        sub(python_scripts, python_re)
 
 
 core.setup(
-	name='ganglia_api',
-	version=__version__,
-	description='API layer that exposes ganglia data in a RESTful JSON manner',
-	author='satterly',
-	author_email='',
-	maintainer='Orchard Systems',
-	maintainer_email='admin@orchardsystems.com',
-	url='https://github.com/teamorchard/ganglia-api',
-	packages=['ganglia'],
-	cmdclass={
-		'set_version': set_version,
-	},
+    name='ganglia_api',
+    version=__version__,
+    description='API layer that exposes ganglia data in a RESTful JSON manner',
+    author='satterly',
+    author_email='',
+    maintainer='Orchard Systems',
+    maintainer_email='admin@orchardsystems.com',
+    url='https://github.com/teamorchard/ganglia-api',
+    packages=['ganglia'],
+    cmdclass={
+        'set_version': set_version,
+    },
 )
-


### PR DESCRIPTION
Add simple pytest using flake8/pep8, cleanup of all warnings except one:

```
pytest --pep8 --flake8
============================= test session starts ==============================
platform linux2 -- Python 2.7.14, pytest-3.8.1, py-1.5.4, pluggy-0.7.1
rootdir: /home/sarnold/my_stuff/work/orchard/git-repos/ganglia-api, inifile: setup.cfg
plugins: pep8-1.0.6, flake8-0.9.1
collected 10 items                                                             

setup.py ..                                                              [ 10%]
ganglia/__init__.py s.                                                   [ 20%]
ganglia/ganglia_api.py ..                                                [ 30%]
ganglia/settings.py ..                                                   [ 40%]
ganglia/version.py ..

=============================== warnings summary ===============================
/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))
/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))

/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))
/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))

/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))
/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))

/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))
/usr/lib64/python2.7/site-packages/flake8/options/config.py:69: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
  found_files.extend(config.read(filename))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============== 9 passed, 1 skipped, 8 warnings in 1.00 seconds ================
```